### PR TITLE
fix agent directory for write-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ gh-issue-sync write-skill --agent codex --scope project
 | `codex` | `~/.codex/skills/` | `.codex/skills/` |
 | `pi` | `~/.pi/skills/` | `.pi/skills/` |
 | `claude` | `~/.claude/skills/` | `.claude/skills/` |
-| `opencode` | `~/.config/opencode/skill/` | `.opencode/skill/` |
+| `opencode` | `~/.config/opencode/skills/` | `.opencode/skills/` |
 | `amp`, `generic` | `~/.config/agents/skills/` | `.agents/skills/` |
 
 To install to a custom location:

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ gh-issue-sync write-skill --agent codex --scope project
 | Agent | User Scope | Project Scope |
 |-------|------------|---------------|
 | `codex` | `~/.codex/skills/` | `.codex/skills/` |
-| `pi` | `~/.pi/skills/` | `.pi/skills/` |
+| `pi` | `~/.pi/agent/skills/` | `.pi/skills/` |
 | `claude` | `~/.claude/skills/` | `.claude/skills/` |
 | `opencode` | `~/.config/opencode/skills/` | `.opencode/skills/` |
 | `amp`, `generic` | `~/.config/agents/skills/` | `.agents/skills/` |

--- a/cmd/gh-issue-sync/main.go
+++ b/cmd/gh-issue-sync/main.go
@@ -347,7 +347,7 @@ func (c *WriteSkillCommand) Execute(args []string) error {
 			} else {
 				agentDir = ".opencode"
 			}
-			skillSubdir = "skill"
+			skillSubdir = "skills"
 		case "amp", "generic":
 			if c.Scope == "user" {
 				agentDir = filepath.Join(".config", "agents")

--- a/cmd/gh-issue-sync/main.go
+++ b/cmd/gh-issue-sync/main.go
@@ -338,7 +338,11 @@ func (c *WriteSkillCommand) Execute(args []string) error {
 		case "codex":
 			agentDir = ".codex"
 		case "pi":
-			agentDir = ".pi"
+			if c.Scope == "user" {
+				agentDir = filepath.Join(".pi", "agent")
+			} else {
+				agentDir = ".pi"
+			}
 		case "claude":
 			agentDir = ".claude"
 		case "opencode":


### PR DESCRIPTION
## opencode
OpenCode changed its skills directory: https://opencode.ai/docs/skills#place-files

```
Project config: .opencode/skills/<name>/SKILL.md
Global config: ~/.config/opencode/skills/<name>/SKILL.md
```

Relevent: https://github.com/mitsuhiko/gh-issue-sync/issues/25#issuecomment-3699004059

## pi
user scope: `~/.pi/agent/skills/<name>/SKILL.md`